### PR TITLE
Recursive embedded packages

### DIFF
--- a/src/DeterministicIoPackaging/DeterministicPackage.cs
+++ b/src/DeterministicIoPackaging/DeterministicPackage.cs
@@ -81,7 +81,7 @@ public static partial class DeterministicPackage
             return;
         }
 
-        sourceStream.CopyTo(targetStream);
+        CopyOrRecurseZip(sourceStream, targetStream);
     }
 
     static async Task DuplicateEntryAsync(Entry sourceEntry, Archive targetArchive, IReadOnlyList<IPatcher> currentPatchers, Cancel cancel)
@@ -121,7 +121,7 @@ public static partial class DeterministicPackage
             return;
         }
 
-        await sourceStream.CopyToAsync(targetStream, cancel);
+        await CopyOrRecurseZipAsync(sourceStream, targetStream, cancel);
     }
 
     static bool IsSpreadsheetXml(Entry entry) =>

--- a/src/DeterministicIoPackaging/DeterministicPackage_Convert.cs
+++ b/src/DeterministicIoPackaging/DeterministicPackage_Convert.cs
@@ -40,6 +40,119 @@ public static partial class DeterministicPackage
         }
     }
 
+    // ZIP local file header signature ("PK\x03\x04").
+    // Used to detect nested ZIP packages (e.g. xlsx/docx/pptx embedded inside
+    // word/embeddings/, ppt/embeddings/, xl/embeddings/) so they can be
+    // recursively normalized rather than copied through verbatim.
+    static readonly byte[] zipLocalFileHeader = [0x50, 0x4B, 0x03, 0x04];
+
+    // ZIP end-of-central-directory signature ("PK\x05\x06") — appears at the
+    // start of an empty ZIP archive that contains no entries.
+    static readonly byte[] zipEndOfCentralDirectory = [0x50, 0x4B, 0x05, 0x06];
+
+    static bool LooksLikeZip(byte[] head, int length)
+    {
+        if (length < 4)
+        {
+            return false;
+        }
+
+        return (head[0] == zipLocalFileHeader[0] &&
+                head[1] == zipLocalFileHeader[1] &&
+                head[2] == zipLocalFileHeader[2] &&
+                head[3] == zipLocalFileHeader[3]) ||
+               (head[0] == zipEndOfCentralDirectory[0] &&
+                head[1] == zipEndOfCentralDirectory[1] &&
+                head[2] == zipEndOfCentralDirectory[2] &&
+                head[3] == zipEndOfCentralDirectory[3]);
+    }
+
+    // Copies source → target, recursively normalizing the entry if its bytes
+    // begin with a ZIP magic signature (i.e. the entry is itself a ZIP package
+    // such as an embedded xlsx inside a docx). Without this recursion, nested
+    // packages flow through with whatever non-deterministic deflate/timestamps
+    // their producer emitted, defeating the deterministic guarantee for the
+    // outer package.
+    static void CopyOrRecurseZip(Stream source, Stream target)
+    {
+        var head = new byte[4];
+        var read = ReadUpTo(source, head, 4);
+
+        if (LooksLikeZip(head, read))
+        {
+            using var buffer = new MemoryStream();
+            buffer.Write(head, 0, read);
+            source.CopyTo(buffer);
+            buffer.Position = 0;
+            Convert(buffer, target);
+            return;
+        }
+
+        if (read > 0)
+        {
+            target.Write(head, 0, read);
+        }
+
+        source.CopyTo(target);
+    }
+
+    static async Task CopyOrRecurseZipAsync(Stream source, Stream target, Cancel cancel)
+    {
+        var head = new byte[4];
+        var read = await ReadUpToAsync(source, head, 4, cancel);
+
+        if (LooksLikeZip(head, read))
+        {
+            using var buffer = new MemoryStream();
+            await buffer.WriteAsync(head, 0, read, cancel);
+            await source.CopyToAsync(buffer, cancel);
+            buffer.Position = 0;
+            await ConvertAsync(buffer, target, cancel);
+            return;
+        }
+
+        if (read > 0)
+        {
+            await target.WriteAsync(head, 0, read, cancel);
+        }
+
+        await source.CopyToAsync(target, cancel);
+    }
+
+    static int ReadUpTo(Stream source, byte[] buffer, int count)
+    {
+        var read = 0;
+        while (read < count)
+        {
+            var n = source.Read(buffer, read, count - read);
+            if (n == 0)
+            {
+                break;
+            }
+
+            read += n;
+        }
+
+        return read;
+    }
+
+    static async Task<int> ReadUpToAsync(Stream source, byte[] buffer, int count, Cancel cancel)
+    {
+        var read = 0;
+        while (read < count)
+        {
+            var n = await source.ReadAsync(buffer, read, count - read, cancel);
+            if (n == 0)
+            {
+                break;
+            }
+
+            read += n;
+        }
+
+        return read;
+    }
+
     static IOrderedEnumerable<Entry> OrderedEntries(this Archive archive) =>
         archive.Entries
             .OrderBy(_ => _.FullName, StringComparer.Ordinal);

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,7 +2,7 @@
 <Project>
   <PropertyGroup>
     <NoWarn>CS1591;CS0649;CA1416;NU1608;NU1109;NU1510</NoWarn>
-    <Version>0.26.0</Version>
+    <Version>0.27.0</Version>
     <LangVersion>preview</LangVersion>
     <AssemblyVersion>1.0.0</AssemblyVersion>
     <Description>Modify System.IO.Packaging (https://learn.microsoft.com/en-us/dotnet/api/system.io.packaging) files to ensure they are deterministic. Helpful for testing, build reproducibility, security verification, and ensuring package integrity across different build environments.</Description>

--- a/src/Tests/OpenXmlTests.cs
+++ b/src/Tests/OpenXmlTests.cs
@@ -546,6 +546,67 @@ public class OpenXmlTests
         };
 
     [Test]
+    public void NestedZipIsRecursivelyNormalized()
+    {
+        // Builds two outer packages that each contain a nested .zip entry whose
+        // only difference is the inner entry's LastWriteTime — a known source of
+        // zip-level non-determinism that the original CopyTo path missed,
+        // because nested packages were never re-normalized.
+        //
+        // Regression test for: snapshots changing on every test run because the
+        // .xlsx Syncfusion embeds inside .docx via word/embeddings/*.xlsx is itself
+        // a non-deterministic zip that was passed through verbatim.
+        var outer1 = BuildOuterWithNestedZip(new(2020, 1, 1, 0, 0, 0, TimeSpan.Zero));
+        var outer2 = BuildOuterWithNestedZip(new(2024, 6, 15, 12, 30, 0, TimeSpan.Zero));
+
+        using var converted1 = DeterministicPackage.Convert(outer1);
+        using var converted2 = DeterministicPackage.Convert(outer2);
+
+        Assert.That(converted1.ToArray(), Is.EqualTo(converted2.ToArray()));
+    }
+
+    [Test]
+    public async Task NestedZipIsRecursivelyNormalizedAsync()
+    {
+        var outer1 = BuildOuterWithNestedZip(new(2020, 1, 1, 0, 0, 0, TimeSpan.Zero));
+        var outer2 = BuildOuterWithNestedZip(new(2024, 6, 15, 12, 30, 0, TimeSpan.Zero));
+
+        using var converted1 = await DeterministicPackage.ConvertAsync(outer1);
+        using var converted2 = await DeterministicPackage.ConvertAsync(outer2);
+
+        Assert.That(converted1.ToArray(), Is.EqualTo(converted2.ToArray()));
+    }
+
+    static MemoryStream BuildOuterWithNestedZip(DateTimeOffset nestedLastWrite)
+    {
+        // Build a nested zip with a single payload entry whose LastWriteTime varies.
+        var nested = new MemoryStream();
+        using (var archive = new Archive(nested, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            var entry = archive.CreateEntry("payload.txt");
+            entry.LastWriteTime = nestedLastWrite;
+            using var es = entry.Open();
+            var bytes = "hello world from nested zip"u8.ToArray();
+            es.Write(bytes, 0, bytes.Length);
+        }
+
+        // Wrap the nested zip inside an outer zip. The outer entry "nested.zip"
+        // contains arbitrary binary that happens to be itself a zip package.
+        var outer = new MemoryStream();
+        using (var archive = new Archive(outer, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            var entry = archive.CreateEntry("word/embeddings/nested.zip");
+            entry.LastWriteTime = new DateTimeOffset(2020, 1, 1, 0, 0, 0, TimeSpan.Zero);
+            using var es = entry.Open();
+            nested.Position = 0;
+            nested.CopyTo(es);
+        }
+
+        outer.Position = 0;
+        return outer;
+    }
+
+    [Test]
     public Task ConvertedPptx()
     {
         var pptxStream = CreatePresentation();


### PR DESCRIPTION
Entries inside a package that are themselves ZIP files (e.g. an xlsx
embedded at word/embeddings/Microsoft_Excel_Worksheet1.xlsx inside a
docx) were copied through verbatim. The nested ZIP retained whatever
non-deterministic deflate output and timestamps its producer emitted,
so the outer package's bytes changed across runs even when every
uncompressed entry was identical.
Detect nested ZIPs by peeking the first 4 bytes for the local-file-
header or end-of-central-directory signature, then recursively run
the entry through Convert before writing it. Non-ZIP entries still
take the straight CopyTo path with the peek bytes restored.
Add NestedZipIsRecursivelyNormalized (sync and async) covering the
case: two outer packages whose nested ZIPs differ only in inner
LastWriteTime must convert to byte-identical output.