### PR TITLE
Handle strict OOXML relationship remapping

### DIFF
--- a/src/DeterministicIoPackaging/Patching/RelationshipRenumber.cs
+++ b/src/DeterministicIoPackaging/Patching/RelationshipRenumber.cs
@@ -1,9 +1,16 @@
 static class RelationshipRenumber
 {
     static XNamespace r = "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
+    // ISO/IEC 29500 Strict variant of the relationships namespace. "Strict Open XML Document" (Word)
+    // and Aspose's Iso29500_2008_Strict emit r:id/r:embed/r:link in this namespace; without matching
+    // it, RemapIds would leave those references pointing at the pre-renumber ids (dangling).
+    static XNamespace rStrict = "http://purl.oclc.org/ooxml/officeDocument/relationships";
     static XName rId = r + "id";
     static XName rEmbed = r + "embed";
     static XName rLink = r + "link";
+    static XName rIdStrict = rStrict + "id";
+    static XName rEmbedStrict = rStrict + "embed";
+    static XName rLinkStrict = rStrict + "link";
 
     public static Dictionary<string, string> RenumberAndSort(XDocument xml, string? entryName = null)
     {
@@ -87,7 +94,8 @@ static class RelationshipRenumber
             for (var attr = descendant.FirstAttribute; attr != null; attr = attr.NextAttribute)
             {
                 var name = attr.Name;
-                if ((name == rId || name == rEmbed || name == rLink) &&
+                if ((name == rId || name == rEmbed || name == rLink ||
+                     name == rIdStrict || name == rEmbedStrict || name == rLinkStrict) &&
                     mapping.TryGetValue(attr.Value, out var newId))
                 {
                     attr.SetValue(newId);

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,7 +2,7 @@
 <Project>
   <PropertyGroup>
     <NoWarn>CS1591;CS0649;CA1416;NU1608;NU1109;NU1510</NoWarn>
-    <Version>0.28.0</Version>
+    <Version>0.29.0</Version>
     <LangVersion>preview</LangVersion>
     <AssemblyVersion>1.0.0</AssemblyVersion>
     <Description>Modify System.IO.Packaging (https://learn.microsoft.com/en-us/dotnet/api/system.io.packaging) files to ensure they are deterministic. Helpful for testing, build reproducibility, security verification, and ensuring package integrity across different build environments.</Description>

--- a/src/Tests/Patching/RelationshipRenumberTests.RemapsTransitionalAndStrictIds.verified.xml
+++ b/src/Tests/Patching/RelationshipRenumberTests.RemapsTransitionalAndStrictIds.verified.xml
@@ -1,0 +1,10 @@
+﻿<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:rs="http://purl.oclc.org/ooxml/officeDocument/relationships">
+  <w:body>
+    <w:hyperlink r:id="DeterministicId1" />
+    <w:blip r:embed="DeterministicId2" />
+    <w:externalLink r:link="DeterministicId3" />
+    <w:hyperlink rs:id="DeterministicId1" />
+    <w:blip rs:embed="DeterministicId2" />
+    <w:externalLink rs:link="DeterministicId3" />
+  </w:body>
+</w:document>

--- a/src/Tests/Patching/RelationshipRenumberTests.cs
+++ b/src/Tests/Patching/RelationshipRenumberTests.cs
@@ -1,0 +1,38 @@
+[TestFixture]
+public class RelationshipRenumberTests
+{
+    [Test]
+    public Task RemapsTransitionalAndStrictIds()
+    {
+        // r: is the Transitional relationships namespace; rs: is the ISO 29500 Strict variant that
+        // "Strict Open XML Document" (Word) and Aspose emit. RemapIds must rewrite both so that,
+        // after the ids in the .rels are renumbered, no r:id/r:embed/r:link is left dangling.
+        var xml =
+            """
+            <?xml version="1.0" encoding="utf-8" standalone="yes"?>
+            <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+                        xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+                        xmlns:rs="http://purl.oclc.org/ooxml/officeDocument/relationships">
+                <w:body>
+                    <w:hyperlink r:id="rId1" />
+                    <w:blip r:embed="rId2" />
+                    <w:externalLink r:link="rId3" />
+                    <w:hyperlink rs:id="rId1" />
+                    <w:blip rs:embed="rId2" />
+                    <w:externalLink rs:link="rId3" />
+                </w:body>
+            </w:document>
+            """;
+        var document = XDocument.Parse(xml);
+
+        var mapping = new Dictionary<string, string>
+        {
+            ["rId1"] = "DeterministicId1",
+            ["rId2"] = "DeterministicId2",
+            ["rId3"] = "DeterministicId3",
+        };
+        RelationshipRenumber.RemapIds(document, mapping);
+
+        return Verify(document);
+    }
+}


### PR DESCRIPTION
Add support for ISO/IEC 29500 Strict relationship namespaces in `RelationshipRenumber`. `RemapIds` now remaps `r:id`, `r:embed`, and `r:link` attributes for both transitional and strict OOXML namespaces, preventing stale relationship references after ID renumbering in strict Word/Aspose documents.